### PR TITLE
Ignore Non Ascii characters for objects Id

### DIFF
--- a/preprocess_cancellation.py
+++ b/preprocess_cancellation.py
@@ -10,6 +10,7 @@ import shutil
 import statistics
 import sys
 import tempfile
+import unicodedata
 from typing import Dict, List, NamedTuple, Optional, Set, Tuple, TypeVar
 
 __version__ = "0.2.0"
@@ -141,8 +142,9 @@ def _dump_coords(coords: List[float]) -> str:
     return ",".join(map("{:0.3f}".format, coords))
 
 
-def _clean_id(id):
-    return re.sub(r"\W+", "_", id).strip("_")
+def _clean_id(oid):
+    oid = unicodedata.normalize('NFKD',oid).encode('ascii','ignore').decode('utf-8') + "_" + str(hex(id(oid)))
+    return re.sub(r"\W+", "_", oid).strip("_")
 
 
 def parse_gcode(line):

--- a/preprocess_cancellation.py
+++ b/preprocess_cancellation.py
@@ -10,7 +10,6 @@ import shutil
 import statistics
 import sys
 import tempfile
-import unicodedata
 from typing import Dict, List, NamedTuple, Optional, Set, Tuple, TypeVar
 
 __version__ = "0.2.0"
@@ -143,7 +142,7 @@ def _dump_coords(coords: List[float]) -> str:
 
 
 def _clean_id(oid):
-    oid = unicodedata.normalize('NFKD',oid).encode('ascii','ignore').decode('utf-8') + "_" + str(hex(id(oid)))
+    oid = oid.encode('ascii','ignore').decode() + str(id(oid))
     return re.sub(r"\W+", "_", oid).strip("_")
 
 

--- a/preprocess_cancellation.py
+++ b/preprocess_cancellation.py
@@ -142,8 +142,7 @@ def _dump_coords(coords: List[float]) -> str:
 
 
 def _clean_id(oid):
-    oid = oid.encode('ascii','ignore').decode() + str(id(oid))
-    return re.sub(r"\W+", "_", oid).strip("_")
+    return re.sub(r"\W+", "_", oid.encode('ascii','ignore').decode()).strip("_") + str(id(oid))
 
 
 def parse_gcode(line):


### PR DESCRIPTION
Hi,
Some users on Voron Discord reported  that their  prints does not start when the sliced filename contains non ascii characters.
Mainly, SuperSlicer is responsible because it produces output as below:
```
...
; object:{"name":"Dé","id":"Dé id:0 copy 0","object_center":[150.000000,150.000000,0.000000],"boundingbox_center":[150.000000,150.000000,15.000000],"boundingbox_size":[30.000000,30.000000,30.000000]}
; plater:{"center":[150.000000,150.000000,0.000000],"boundingbox_center":[150.000000,150.000000,15.000000],"boundingbox_size":[30.000000,30.000000,30.000000]}

M73 P0 R30
;TYPE:Custom
; custom gcode: start_gcode
...
```
I don't know yet if the other slicers behave the same. 

As preprocess_cancellation uses object name as id , non-ascii characters are injected into gcode, producing klipper errors.

The solution I provide is : ignore the non ascii characters and add an ID to the string (in case of similar strings , except non-ascii)

Thanks, 